### PR TITLE
Add Dolby Vision FourCC

### DIFF
--- a/mp4/non_iso.py
+++ b/mp4/non_iso.py
@@ -70,7 +70,9 @@ class Avc1Box(Mp4FullBox):
             fp.seek(self.start_of_box + self.size)
 
 
-DvheBox = Dvh1Box = DvavBox = Dva1Box = Hvc1Box = Hev1Box = Avc3Box = Avc1Box
+DvheBox = Dvh1Box = DvavBox = Dva1Box = Avc1Box
+Hvc1Box = Hev1Box = Avc1Box
+Avc4Box = Avc3Box = Avc2Box = Avc1Box
 
 
 class AvccBox(Mp4Box):

--- a/mp4/non_iso.py
+++ b/mp4/non_iso.py
@@ -70,7 +70,7 @@ class Avc1Box(Mp4FullBox):
             fp.seek(self.start_of_box + self.size)
 
 
-Hvc1Box = Avc1Box
+DvheBox = Dvh1Box = DvavBox = Dva1Box = Hvc1Box = Hev1Box = Avc3Box = Avc1Box
 
 
 class AvccBox(Mp4Box):


### PR DESCRIPTION
Add Dolby Vision FourCC Dvhe, Dvh1, Dvav, Dva1 identical to Avc1
Add AVC FourCC Avc2, Avc3, Avc4 identical to Avc1
Add HEVC FourCC Hvc1 identical to Avc1

Cf. document [dolby-vision-bitstreams-within-the-iso-base-media-file-format-v2.1.2.pdf](https://www.dolby.com/us/en/technologies/dolby-vision/dolby-vision-bitstreams-within-the-iso-base-media-file-format-v2.1.2.pdf).