### PR TITLE
Add hvcE box

### DIFF
--- a/mp4/non_iso.py
+++ b/mp4/non_iso.py
@@ -158,7 +158,9 @@ class HvccBox(Mp4Box):
         finally:
             fp.seek(self.start_of_box + self.size)
 
-
+HvceBox = HvccBox
+            
+            
 class DvccBox(Mp4Box):
 
     def __init__(self, fp, header, parent):


### PR DESCRIPTION
hvcC is for DV HEVC Base Layer, hvcE is for DV HEVC Enhancement Layer. They have strictly the same structure, cf. document "Dolby_Vision_Bitstreams_Within_the_ISO_Base_Media_File_Format_v2_1_2.pdf":

```
The syntax of the Dolby Vision enhancement-layer HEVC configuration box is shown here.
class DolbyVisionELHEVCConfigurationBox() extends Box(‘hvcE’)
{
    HEVCDecoderConfigurationRecord() HEVCConfig;
}
```