### PR TITLE
Use separate class type for each box

### DIFF
--- a/mp4analyser/iso.py
+++ b/mp4analyser/iso.py
@@ -209,7 +209,7 @@ class FreeBox(Mp4Box):
             fp.seek(self.start_of_box + self.size)
 
 
-SkipBox = FreeBox
+class SkipBox(FreeBox): pass
 
 
 class FtypBox(Mp4Box):
@@ -230,7 +230,7 @@ class FtypBox(Mp4Box):
             fp.seek(self.start_of_box + self.size)
 
 
-StypBox = FtypBox
+class StypBox(FtypBox): pass
 
 
 class PdinBox(Mp4FullBox):
@@ -262,9 +262,26 @@ class ContainerBox(Mp4Box):
 
 
 # All these are pure container boxes
-DinfBox = MinfBox = MdiaBox = TrefBox = EdtsBox = TrafBox = TrakBox = MoofBox = MoovBox = ContainerBox
-UdtaBox = TrgrBox = MvexBox = MfraBox = StrkBox = StrdBox = RinfBox = SinfBox = MecoBox = ContainerBox
-GmhdBox = ContainerBox
+class DinfBox(ContainerBox): pass
+class MinfBox(ContainerBox): pass
+class MdiaBox(ContainerBox): pass
+class TrefBox(ContainerBox): pass
+class EdtsBox(ContainerBox): pass
+class TrafBox(ContainerBox): pass
+class TrakBox(ContainerBox): pass
+class MoofBox(ContainerBox): pass
+class MoovBox(ContainerBox): pass
+class UdtaBox(ContainerBox): pass
+class TrgrBox(ContainerBox): pass
+class MvexBox(ContainerBox): pass
+class MfraBox(ContainerBox): pass
+class StrkBox(ContainerBox): pass
+class StrdBox(ContainerBox): pass
+class RinfBox(ContainerBox): pass
+class SinfBox(ContainerBox): pass
+class MecoBox(ContainerBox): pass
+class GmdhBox(ContainerBox): pass
+
 
 class MetaBox(Mp4Box):
     """

--- a/mp4analyser/non_iso.py
+++ b/mp4analyser/non_iso.py
@@ -65,9 +65,16 @@ class Avc1Box(Mp4FullBox):
             fp.seek(self.start_of_box + self.size)
 
 
-DvheBox = Dvh1Box = DvavBox = Dva1Box = Avc1Box
-Hvc1Box = Hev1Box = Av01Box = Avc1Box
-Avc4Box = Avc3Box = Avc2Box = Avc1Box
+class DvheBox(Avc1Box): pass
+class Dvh1Box(Avc1Box): pass
+class DvavBox(Avc1Box): pass
+class Dva1Box(Avc1Box): pass
+class Hvc1Box(Avc1Box): pass
+class Hev1Box(Avc1Box): pass
+class Av01Box(Avc1Box): pass
+class Avc2Box(Avc1Box): pass
+class Avc3Box(Avc1Box): pass
+class Avc4Box(Avc1Box): pass
 
 
 class AvccBox(Mp4Box):
@@ -206,7 +213,8 @@ class DvccBox(Mp4Box):
             fp.seek(self.start_of_box + self.size)
 
 
-DvvcBox = DvccBox
+class DvvcBox(DvccBox): pass
+
 
 class BtrtBox(Mp4Box):
 
@@ -257,7 +265,8 @@ class Mp4aBox(Mp4Box):
             fp.seek(self.start_of_box + self.size)
 
 
-Ac_3Box = Ec_3Box = Mp4aBox
+class Ac_3Box(Mp4aBox): pass
+class Ec_3Box(Mp4aBox): pass
 
 
 class EsdsBox(Mp4FullBox):


### PR DESCRIPTION
This change simplifies distinguishing boxes when using the mp4analyser module in interactive python sessions.

Before:
```
In [3]: mp4.child_boxes[1]
Out[3]: <mp4analyser.iso.ContainerBox at 0x7f005f572cf8>

In [4]: mp4.child_boxes[2]
Out[4]: <mp4analyser.iso.ContainerBox at 0x7f005f559ac8>
```

After:
```
In [3]: mp4.child_boxes[1]
Out[3]: <mp4analyser.iso.MoovBox at 0x7f6c9194f128>

In [4]: mp4.child_boxes[2]
Out[4]: <mp4analyser.iso.MoofBox at 0x7f6c918e7128>
```
