### PR TITLE
Fix KeyError in _generate_samples_from_moofs()

### DIFF
--- a/mp4analyser/iso.py
+++ b/mp4analyser/iso.py
@@ -172,12 +172,19 @@ class Mp4File:
                                     'sample_count': trun.box_info['sample_count'],
                                     'run_samples': []
                                     }
+                        has_sample_size = False
+                        if int(trun.box_info['flags'][-3], 16) & 2 == 2:
+                            has_sample_size = True
                         for l, sample in enumerate(trun.box_info['samples'], 1):
+                            if not has_sample_size:
+                                sample_size = tfhd.box_info['default_sample_size']
+                            else:
+                                sample_size = sample['sample_size']
                             run_dict['run_samples'].append({'sample_ID': l,
-                                                            'size': sample['sample_size'],
+                                                            'size': sample_size,
                                                             'offset': data_offset
                                                             })
-                            data_offset += sample['sample_size']
+                            data_offset += sample_size
                         for mdat in media_segment['mdat_boxes']:
                             if mdat.start_of_box < run_dict['run_offset'] and (mdat.start_of_box
                                                                                + mdat.size) >= data_offset:


### PR DESCRIPTION
Is see the following exception in the Mp4File constructor with a fragmented mp4 file:
```
In [3]: mp4 = Mp4File('/home/mari/Desktop/play/Big Buck Bunny Demo frag.mp4')
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-3-992bcc60d791> in <module>()
----> 1 mp4 = Mp4File('/home/mari/Desktop/play/Big Buck Bunny Demo frag.mp4')

/home/mari/Code/oss/mp4analyser/mp4analyser/iso.py in __init__(self, filename)
     67         f.close()
     68         self._generate_samples_from_moov()
---> 69         self._generate_samples_from_moofs()
     70 
     71     def _generate_samples_from_moov(self):

/home/mari/Code/oss/mp4analyser/mp4analyser/iso.py in _generate_samples_from_moofs(self)
    175                         for l, sample in enumerate(trun.box_info['samples'], 1):
    176                             run_dict['run_samples'].append({'sample_ID': l,
--> 177                                                             'size': sample['sample_size'],
    178                                                             'offset': data_offset
    179                                                             })

KeyError: 'sample_size'
```

Apparently, the sample list in the trun box is empty. That is it has 173 zero-sized records.
```
In [2]: mp4 = Mp4File('/home/mari/Desktop/play/Big Buck Bunny Demo frag.mp4')
> /home/mari/Code/oss/mp4analyser/mp4analyser/iso.py(178)_generate_samples_from_moofs()
    177                                 import ipdb; ipdb.set_trace()
--> 178                             run_dict['run_samples'].append({'sample_ID': l,
    179                                                             'size': sample['sample_size'],

ipdb> sample
{}
ipdb> trun
<mp4analyser.iso.TrunBox object at 0x7f07647a9048>
ipdb> trun.box_info
{'version': 0, 'flags': '0x000001', 'sample_count': 173, 'data_offset': 402054, 'samples': [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}]}
ipdb> trun.byte_string
ipdb> 
ipdb> trun.get_bytes
<bound method Mp4Box.get_bytes of <mp4analyser.iso.TrunBox object at 0x7f07647a9048>>
ipdb> trun.get_bytes()
b'\x00\x00\x00\x14trun\x00\x00\x00\x01\x00\x00\x00\xad\x00\x06"\x86'
ipdb> 0xad
173
ipdb> quit
```

The suggested fix uses the `default_sample_size` from the `traf` box as defined by iso if the `sample_size` field is not present in the records in the trun box.