### PR TITLE
Make sample generation optional in Mp4File constructor

### DIFF
--- a/mp4analyser/iso.py
+++ b/mp4analyser/iso.py
@@ -47,7 +47,7 @@ def box_factory(fp, header, parent):
 
 class Mp4File:
     """ Mp4File Class, effectively the top-level container """
-    def __init__(self, filename):
+    def __init__(self, filename, *, generate_samples=True):
         self.filename = filename
         self.type = 'file'
         self.child_boxes = []
@@ -65,8 +65,9 @@ class Mp4File:
                 else:
                     f.seek(-4, 1)
         f.close()
-        self._generate_samples_from_moov()
-        self._generate_samples_from_moofs()
+        if generate_samples:
+            self._generate_samples_from_moov()
+            self._generate_samples_from_moofs()
 
     def _generate_samples_from_moov(self):
         """ identify media samples in mdat for full mp4 file """


### PR DESCRIPTION
I'm using mp4analyzer as a python module to interactively explore the box and metadata structure of mp4 files. The sample generation process is often not required. So I suggest to make it optional, on by default.